### PR TITLE
Add EF Core context with migration setup

### DIFF
--- a/ProjectPortfolio/Model/DesignTimePortfolioContextFactory.cs
+++ b/ProjectPortfolio/Model/DesignTimePortfolioContextFactory.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace Model;
+
+public class DesignTimePortfolioContextFactory : IDesignTimeDbContextFactory<PortfolioContext>
+{
+    public PortfolioContext CreateDbContext(string[] args)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<PortfolioContext>();
+        optionsBuilder.UseSqlite("Data Source=portfolio.db");
+        return new PortfolioContext(optionsBuilder.Options);
+    }
+}

--- a/ProjectPortfolio/Model/Model.csproj
+++ b/ProjectPortfolio/Model/Model.csproj
@@ -5,5 +5,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
+  </ItemGroup>
 
 </Project>

--- a/ProjectPortfolio/Model/PortfolioContext.cs
+++ b/ProjectPortfolio/Model/PortfolioContext.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+using Model.Entity;
+
+namespace Model;
+
+public class PortfolioContext : DbContext
+{
+    public PortfolioContext(DbContextOptions<PortfolioContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Profile> Profiles => Set<Profile>();
+    public DbSet<EmploymentRecord> EmploymentRecords => Set<EmploymentRecord>();
+    public DbSet<EducationRecord> EducationRecords => Set<EducationRecord>();
+    public DbSet<Project> Projects => Set<Project>();
+    public DbSet<Skill> Skills => Set<Skill>();
+    public DbSet<Certification> Certifications => Set<Certification>();
+}

--- a/ProjectPortfolio/WebAPI/Program.cs
+++ b/ProjectPortfolio/WebAPI/Program.cs
@@ -1,8 +1,13 @@
+using Microsoft.EntityFrameworkCore;
+using Model;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 
 // Add services to the container.
+builder.Services.AddDbContext<Model.PortfolioContext>(options =>
+    options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection") ?? "Data Source=portfolio.db"));
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle

--- a/ProjectPortfolio/WebAPI/WebAPI.csproj
+++ b/ProjectPortfolio/WebAPI/WebAPI.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ProjectPortfolio.ServiceDefaults\ProjectPortfolio.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Model\Model.csproj" />
   </ItemGroup>
 
 </Project>

--- a/ProjectPortfolio/WebAPI/appsettings.Development.json
+++ b/ProjectPortfolio/WebAPI/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=portfolio.db"
   }
 }

--- a/ProjectPortfolio/WebAPI/appsettings.json
+++ b/ProjectPortfolio/WebAPI/appsettings.json
@@ -6,4 +6,7 @@
     }
   },
   "AllowedHosts": "*"
+  ,"ConnectionStrings": {
+    "DefaultConnection": "Data Source=portfolio.db"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -14,3 +14,15 @@ The `Profile` class includes identity details useful for rendering a portfolio s
 - Lists of employment records, education records, certifications and personal projects
 
 Each project has been updated so that every class resides in its own file.
+
+## Database migrations
+
+The `Model` project includes an EF Core `DbContext` so you can generate a
+database schema using code-first migrations. To add the initial migration run:
+
+```bash
+dotnet ef migrations add InitialCreate --project ProjectPortfolio/Model --startup-project ProjectPortfolio/ProjectPortfolio.AppHost
+```
+
+Migrations will be placed in the `Model` project and can be applied with
+`dotnet ef database update`.


### PR DESCRIPTION
## Summary
- add `PortfolioContext` with `DbSet`s for entities
- provide design-time factory for migrations
- reference EF Core packages in the Model project
- register the context in WebAPI and add Model reference
- document how to create migrations
- include connection strings in WebAPI settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881149349b88326a1f461040ff2cc3d