### PR TITLE
Add in-memory data and CRUD controllers

### DIFF
--- a/ProjectPortfolio/Model/Model.csproj
+++ b/ProjectPortfolio/Model/Model.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/ProjectPortfolio/WebAPI/Controllers/CertificationsController.cs
+++ b/ProjectPortfolio/WebAPI/Controllers/CertificationsController.cs
@@ -1,0 +1,10 @@
+using Model.Entity;
+using WebAPI.Data;
+using System.Collections.Generic;
+
+namespace WebAPI.Controllers;
+
+public class CertificationsController : CrudController<Certification>
+{
+    protected override List<Certification> Items => InMemoryData.Certifications;
+}

--- a/ProjectPortfolio/WebAPI/Controllers/CrudController.cs
+++ b/ProjectPortfolio/WebAPI/Controllers/CrudController.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Mvc;
+using Model.Entity.Abstract;
+using WebAPI.Data;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace WebAPI.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public abstract class CrudController<T> : ControllerBase where T : AEntity
+{
+    protected abstract List<T> Items { get; }
+
+    [HttpGet]
+    public ActionResult<IEnumerable<T>> GetAll()
+    {
+        return Ok(Items);
+    }
+
+    [HttpGet("{id}")]
+    public ActionResult<T> GetById(int id)
+    {
+        var item = Items.FirstOrDefault(e => e.ID == id);
+        return item is null ? NotFound() : Ok(item);
+    }
+
+    [HttpPost]
+    public ActionResult<T> Create(T item)
+    {
+        item.ID = InMemoryData.GetNextId(Items);
+        Items.Add(item);
+        return CreatedAtAction(nameof(GetById), new { id = item.ID }, item);
+    }
+
+    [HttpPut("{id}")]
+    public IActionResult Update(int id, T item)
+    {
+        var existing = Items.FirstOrDefault(e => e.ID == id);
+        if (existing is null) return NotFound();
+
+        var index = Items.IndexOf(existing);
+        item.ID = id;
+        Items[index] = item;
+        return NoContent();
+    }
+
+    [HttpDelete("{id}")]
+    public IActionResult Delete(int id)
+    {
+        var item = Items.FirstOrDefault(e => e.ID == id);
+        if (item is null) return NotFound();
+
+        Items.Remove(item);
+        return NoContent();
+    }
+}

--- a/ProjectPortfolio/WebAPI/Controllers/EducationRecordsController.cs
+++ b/ProjectPortfolio/WebAPI/Controllers/EducationRecordsController.cs
@@ -1,0 +1,10 @@
+using Model.Entity;
+using WebAPI.Data;
+using System.Collections.Generic;
+
+namespace WebAPI.Controllers;
+
+public class EducationRecordsController : CrudController<EducationRecord>
+{
+    protected override List<EducationRecord> Items => InMemoryData.EducationRecords;
+}

--- a/ProjectPortfolio/WebAPI/Controllers/EmploymentRecordsController.cs
+++ b/ProjectPortfolio/WebAPI/Controllers/EmploymentRecordsController.cs
@@ -1,0 +1,10 @@
+using Model.Entity;
+using WebAPI.Data;
+using System.Collections.Generic;
+
+namespace WebAPI.Controllers;
+
+public class EmploymentRecordsController : CrudController<EmploymentRecord>
+{
+    protected override List<EmploymentRecord> Items => InMemoryData.EmploymentRecords;
+}

--- a/ProjectPortfolio/WebAPI/Controllers/ProfilesController.cs
+++ b/ProjectPortfolio/WebAPI/Controllers/ProfilesController.cs
@@ -1,0 +1,9 @@
+using Model.Entity;
+using WebAPI.Data;
+
+namespace WebAPI.Controllers;
+
+public class ProfilesController : CrudController<Profile>
+{
+    protected override List<Profile> Items => InMemoryData.Profiles;
+}

--- a/ProjectPortfolio/WebAPI/Controllers/ProjectsController.cs
+++ b/ProjectPortfolio/WebAPI/Controllers/ProjectsController.cs
@@ -1,0 +1,10 @@
+using Model.Entity;
+using WebAPI.Data;
+using System.Collections.Generic;
+
+namespace WebAPI.Controllers;
+
+public class ProjectsController : CrudController<Project>
+{
+    protected override List<Project> Items => InMemoryData.Projects;
+}

--- a/ProjectPortfolio/WebAPI/Controllers/SkillsController.cs
+++ b/ProjectPortfolio/WebAPI/Controllers/SkillsController.cs
@@ -1,0 +1,10 @@
+using Model.Entity;
+using WebAPI.Data;
+using System.Collections.Generic;
+
+namespace WebAPI.Controllers;
+
+public class SkillsController : CrudController<Skill>
+{
+    protected override List<Skill> Items => InMemoryData.Skills;
+}

--- a/ProjectPortfolio/WebAPI/Data/InMemoryData.cs
+++ b/ProjectPortfolio/WebAPI/Data/InMemoryData.cs
@@ -1,0 +1,21 @@
+using Model.Entity;
+using Model.Entity.Abstract;
+
+namespace WebAPI.Data;
+
+public static class InMemoryData
+{
+    public static List<Profile> Profiles { get; } = new();
+    public static List<Project> Projects { get; } = new();
+    public static List<Skill> Skills { get; } = new();
+    public static List<Certification> Certifications { get; } = new();
+    public static List<EducationRecord> EducationRecords { get; } = new();
+    public static List<EmploymentRecord> EmploymentRecords { get; } = new();
+
+    public static int GetNextId<T>(List<T> items) where T : AEntity
+    {
+        if (items.Count == 0)
+            return 1;
+        return items.Max(i => i.ID) + 1;
+    }
+}

--- a/ProjectPortfolio/WebAPI/WebAPI.csproj
+++ b/ProjectPortfolio/WebAPI/WebAPI.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ProjectPortfolio.ServiceDefaults\ProjectPortfolio.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Model\Model.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add Microsoft.EntityFrameworkCore to Model project for Index attribute
- reference Model project in WebAPI
- create an in-memory data store
- implement generic `CrudController` and specific controllers for all model entities

## Testing
- `dotnet build ProjectPortfolio/WebAPI/WebAPI.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688116e71b10832693eac4a5bde76c8c