### PR TITLE
Add repository pattern with DI support

### DIFF
--- a/ProjectPortfolio/Model/DesignTimePortfolioContextFactory.cs
+++ b/ProjectPortfolio/Model/DesignTimePortfolioContextFactory.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace Model;
+
+public class DesignTimePortfolioContextFactory : IDesignTimeDbContextFactory<PortfolioContext>
+{
+    public PortfolioContext CreateDbContext(string[] args)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<PortfolioContext>();
+        optionsBuilder.UseSqlite("Data Source=portfolio.db");
+        return new PortfolioContext(optionsBuilder.Options);
+    }
+}

--- a/ProjectPortfolio/Model/Model.csproj
+++ b/ProjectPortfolio/Model/Model.csproj
@@ -5,5 +5,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
+  </ItemGroup>
 
 </Project>

--- a/ProjectPortfolio/Model/PortfolioContext.cs
+++ b/ProjectPortfolio/Model/PortfolioContext.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+using Model.Entity;
+
+namespace Model;
+
+public class PortfolioContext : DbContext
+{
+    public PortfolioContext(DbContextOptions<PortfolioContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Profile> Profiles => Set<Profile>();
+    public DbSet<EmploymentRecord> EmploymentRecords => Set<EmploymentRecord>();
+    public DbSet<EducationRecord> EducationRecords => Set<EducationRecord>();
+    public DbSet<Project> Projects => Set<Project>();
+    public DbSet<Skill> Skills => Set<Skill>();
+    public DbSet<Certification> Certifications => Set<Certification>();
+}

--- a/ProjectPortfolio/Model/Repository/EfRepository.cs
+++ b/ProjectPortfolio/Model/Repository/EfRepository.cs
@@ -1,0 +1,48 @@
+namespace Model.Repository;
+
+using Microsoft.EntityFrameworkCore;
+using Model.Entity.Abstract;
+
+public class EfRepository<T> : IRepository<T> where T : AEntity
+{
+    private readonly PortfolioContext _context;
+    private readonly DbSet<T> _dbSet;
+
+    public EfRepository(PortfolioContext context)
+    {
+        _context = context;
+        _dbSet = context.Set<T>();
+    }
+
+    public async Task<List<T>> GetAllAsync()
+    {
+        return await _dbSet.AsNoTracking().ToListAsync();
+    }
+
+    public async Task<T?> GetByIdAsync(int id)
+    {
+        return await _dbSet.FindAsync(id);
+    }
+
+    public async Task AddAsync(T entity)
+    {
+        _dbSet.Add(entity);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task UpdateAsync(T entity)
+    {
+        _dbSet.Update(entity);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var entity = await GetByIdAsync(id);
+        if (entity != null)
+        {
+            _dbSet.Remove(entity);
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/ProjectPortfolio/Model/Repository/IProfileRepository.cs
+++ b/ProjectPortfolio/Model/Repository/IProfileRepository.cs
@@ -1,0 +1,8 @@
+namespace Model.Repository;
+
+using Model.Entity;
+
+public interface IProfileRepository : IRepository<Profile>
+{
+    Task<Profile?> GetFullProfileAsync(int id);
+}

--- a/ProjectPortfolio/Model/Repository/IRepository.cs
+++ b/ProjectPortfolio/Model/Repository/IRepository.cs
@@ -1,0 +1,12 @@
+namespace Model.Repository;
+
+using Model.Entity.Abstract;
+
+public interface IRepository<T> where T : AEntity
+{
+    Task<List<T>> GetAllAsync();
+    Task<T?> GetByIdAsync(int id);
+    Task AddAsync(T entity);
+    Task UpdateAsync(T entity);
+    Task DeleteAsync(int id);
+}

--- a/ProjectPortfolio/Model/Repository/ProfileRepository.cs
+++ b/ProjectPortfolio/Model/Repository/ProfileRepository.cs
@@ -1,0 +1,27 @@
+namespace Model.Repository;
+
+using Microsoft.EntityFrameworkCore;
+using Model;
+using Model.Entity;
+
+public class ProfileRepository : EfRepository<Profile>, IProfileRepository
+{
+    private readonly PortfolioContext _context;
+
+    public ProfileRepository(PortfolioContext context) : base(context)
+    {
+        _context = context;
+    }
+
+    public async Task<Profile?> GetFullProfileAsync(int id)
+    {
+        return await _context.Profiles
+            .Include(p => p.EmploymentHistory)
+                .ThenInclude(e => e.Projects)
+            .Include(p => p.EducationHistory)
+            .Include(p => p.Certifications)
+            .Include(p => p.PersonalProjects)
+                .ThenInclude(pr => pr.Skills)
+            .FirstOrDefaultAsync(p => p.ID == id);
+    }
+}

--- a/ProjectPortfolio/WebAPI/Program.cs
+++ b/ProjectPortfolio/WebAPI/Program.cs
@@ -1,8 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Model;
+using Model.Repository;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 
 // Add services to the container.
+builder.Services.AddDbContext<Model.PortfolioContext>(options =>
+    options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection") ?? "Data Source=portfolio.db"));
+builder.Services.AddScoped(typeof(IRepository<>), typeof(EfRepository<>));
+builder.Services.AddScoped<IProfileRepository, ProfileRepository>();
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle

--- a/ProjectPortfolio/WebAPI/WebAPI.csproj
+++ b/ProjectPortfolio/WebAPI/WebAPI.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ProjectPortfolio.ServiceDefaults\ProjectPortfolio.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Model\Model.csproj" />
   </ItemGroup>
 
 </Project>

--- a/ProjectPortfolio/WebAPI/appsettings.Development.json
+++ b/ProjectPortfolio/WebAPI/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=portfolio.db"
   }
 }

--- a/ProjectPortfolio/WebAPI/appsettings.json
+++ b/ProjectPortfolio/WebAPI/appsettings.json
@@ -6,4 +6,7 @@
     }
   },
   "AllowedHosts": "*"
+  ,"ConnectionStrings": {
+    "DefaultConnection": "Data Source=portfolio.db"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -14,3 +14,25 @@ The `Profile` class includes identity details useful for rendering a portfolio s
 - Lists of employment records, education records, certifications and personal projects
 
 Each project has been updated so that every class resides in its own file.
+
+## Database migrations
+
+The `Model` project includes an EF Core `DbContext` so you can generate a
+database schema using code-first migrations. To add the initial migration run:
+
+```bash
+dotnet ef migrations add InitialCreate --project ProjectPortfolio/Model --startup-project ProjectPortfolio/ProjectPortfolio.AppHost
+```
+
+Migrations will be placed in the `Model` project and can be applied with
+`dotnet ef database update`.
+
+## Data access repositories
+
+The Model project contains a simple repository pattern. `IRepository<T>` defines
+CRUD methods for entities derived from `AEntity`. `EfRepository<T>` implements
+this interface using `PortfolioContext`. The `ProfileRepository` provides a
+custom method for loading a profile with all related entities.
+
+The WebAPI project registers these repositories with dependency injection so
+controllers can depend on abstractions.


### PR DESCRIPTION
## Summary
- define `IRepository<T>` and `EfRepository<T>` for CRUD operations
- create `ProfileRepository` with method to load all related profile data
- register repositories for DI in WebAPI
- document repository usage in README

## Testing
- `dotnet build ProjectPortfolio/ProjectPortfolio.sln -warnaserror -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881149349b88326a1f461040ff2cc3d