### PR TITLE
Implement multi-portfolio site

### DIFF
--- a/ProjectPortfolio/Model/Entity/Person.cs
+++ b/ProjectPortfolio/Model/Entity/Person.cs
@@ -1,0 +1,13 @@
+using Model.Entity.Abstract;
+
+namespace Model.Entity;
+
+public class Person : AEntity
+{
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public string Location { get; set; }
+    public string ContactEmail { get; set; }
+    public string Phone { get; set; }
+    public List<Profile> Portfolios { get; set; } = new();
+}

--- a/ProjectPortfolio/Model/Entity/Profile.cs
+++ b/ProjectPortfolio/Model/Entity/Profile.cs
@@ -4,12 +4,9 @@ namespace Model.Entity;
 
 public class Profile : AEntity
 {
-    public string FirstName { get; set; }
-    public string LastName { get; set; }
+    public int PersonId { get; set; }
+    public Person Person { get; set; }
     public string Title { get; set; }
-    public string Location { get; set; }
-    public string ContactEmail { get; set; }
-    public string Phone { get; set; }
     public string SelfDescription { get; set; }
     public List<EmploymentRecord> EmploymentHistory { get; set; } = new();
     public List<EducationRecord> EducationHistory { get; set; } = new();

--- a/ProjectPortfolio/Model/PortfolioContext.cs
+++ b/ProjectPortfolio/Model/PortfolioContext.cs
@@ -10,6 +10,7 @@ public class PortfolioContext : DbContext
     }
 
     public DbSet<Profile> Profiles => Set<Profile>();
+    public DbSet<Person> Persons => Set<Person>();
     public DbSet<EmploymentRecord> EmploymentRecords => Set<EmploymentRecord>();
     public DbSet<EducationRecord> EducationRecords => Set<EducationRecord>();
     public DbSet<Project> Projects => Set<Project>();

--- a/ProjectPortfolio/WebAPI/Data/InMemoryData.cs
+++ b/ProjectPortfolio/WebAPI/Data/InMemoryData.cs
@@ -5,6 +5,7 @@ namespace WebAPI.Data;
 
 public static class InMemoryData
 {
+    public static List<Person> Persons { get; } = new();
     public static List<Profile> Profiles { get; } = new();
     public static List<Project> Projects { get; } = new();
     public static List<Skill> Skills { get; } = new();

--- a/ProjectPortfolio/WebAppRazor/Pages/Index.cshtml
+++ b/ProjectPortfolio/WebAppRazor/Pages/Index.cshtml
@@ -4,7 +4,19 @@
     ViewData["Title"] = "Home page";
 }
 
-<div class="text-center">
-    <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+<h1 class="mb-3">Portfolios</h1>
+<div class="row row-cols-1 row-cols-md-3 g-4">
+@foreach (var p in Model.Portfolios)
+{
+    <div class="col">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">@p.Person.FirstName @p.Person.LastName</h5>
+                <h6 class="card-subtitle mb-2 text-muted">@p.Title</h6>
+                <p class="card-text">@p.SelfDescription</p>
+                <a asp-page="/Portfolio" asp-route-id="@p.ID" class="stretched-link"></a>
+            </div>
+        </div>
+    </div>
+}
 </div>

--- a/ProjectPortfolio/WebAppRazor/Pages/Index.cshtml.cs
+++ b/ProjectPortfolio/WebAppRazor/Pages/Index.cshtml.cs
@@ -6,14 +6,18 @@ namespace WebAppRazor.Pages;
 public class IndexModel : PageModel
 {
     private readonly ILogger<IndexModel> _logger;
+    private readonly Services.PortfolioApiClient _api;
 
-    public IndexModel(ILogger<IndexModel> logger)
+    public List<Model.Entity.Profile> Portfolios { get; set; } = new();
+
+    public IndexModel(ILogger<IndexModel> logger, Services.PortfolioApiClient api)
     {
         _logger = logger;
+        _api = api;
     }
 
-    public void OnGet()
+    public async Task OnGetAsync()
     {
-
+        Portfolios = await _api.GetProfilesAsync();
     }
 }

--- a/ProjectPortfolio/WebAppRazor/Pages/Portfolio/Index.cshtml
+++ b/ProjectPortfolio/WebAppRazor/Pages/Portfolio/Index.cshtml
@@ -1,0 +1,23 @@
+@page "{id:int}"
+@model WebAppRazor.Pages.Portfolio.IndexModel
+@{
+    ViewData["Title"] = "Portfolio";
+}
+
+@if (Model.Profile is null)
+{
+    <p>Portfolio not found.</p>
+}
+else
+{
+    <h1>@Model.Profile.Person.FirstName @Model.Profile.Person.LastName - @Model.Profile.Title</h1>
+    <p>@Model.Profile.SelfDescription</p>
+
+    <h2>Projects</h2>
+    <ul>
+    @foreach (var proj in Model.Profile.AllProjects)
+    {
+        <li>@proj.Title</li>
+    }
+    </ul>
+}

--- a/ProjectPortfolio/WebAppRazor/Pages/Portfolio/Index.cshtml.cs
+++ b/ProjectPortfolio/WebAppRazor/Pages/Portfolio/Index.cshtml.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using WebAppRazor.Services;
+using Model.Entity;
+
+namespace WebAppRazor.Pages.Portfolio;
+
+public class IndexModel : PageModel
+{
+    private readonly PortfolioApiClient _api;
+
+    public Profile? Profile { get; set; }
+
+    public IndexModel(PortfolioApiClient api)
+    {
+        _api = api;
+    }
+
+    public async Task OnGetAsync(int id)
+    {
+        Profile = await _api.GetProfileAsync(id);
+    }
+}

--- a/ProjectPortfolio/WebAppRazor/Program.cs
+++ b/ProjectPortfolio/WebAppRazor/Program.cs
@@ -2,6 +2,11 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 
+builder.Services.AddHttpClient<WebAppRazor.Services.PortfolioApiClient>(client =>
+{
+    client.BaseAddress = new Uri("http://webapi");
+});
+
 // Add services to the container.
 builder.Services.AddRazorPages();
 

--- a/ProjectPortfolio/WebAppRazor/Services/PortfolioApiClient.cs
+++ b/ProjectPortfolio/WebAppRazor/Services/PortfolioApiClient.cs
@@ -1,0 +1,25 @@
+using System.Net.Http.Json;
+using Model.Entity;
+
+namespace WebAppRazor.Services;
+
+public class PortfolioApiClient
+{
+    private readonly HttpClient _client;
+
+    public PortfolioApiClient(HttpClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<List<Profile>> GetProfilesAsync()
+    {
+        var result = await _client.GetFromJsonAsync<List<Profile>>("profiles");
+        return result ?? new List<Profile>();
+    }
+
+    public async Task<Profile?> GetProfileAsync(int id)
+    {
+        return await _client.GetFromJsonAsync<Profile>($"profiles/{id}");
+    }
+}

--- a/ProjectPortfolio/WebAppRazor/WebAppRazor.csproj
+++ b/ProjectPortfolio/WebAppRazor/WebAppRazor.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ProjectPortfolio.ServiceDefaults\ProjectPortfolio.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Model\Model.csproj" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -2,14 +2,19 @@
 
 This repository contains a sample .NET project portfolio. The `Model` project defines entities that describe a person's professional profile, employment history, education and skills.
 
-## Profile model
+## Model overview
 
-The `Profile` class includes identity details useful for rendering a portfolio site:
+Portfolios are now associated with a `Person` so a single person can publish multiple portfolios.
+
+`Person` contains contact information:
 
 - `FirstName` and `LastName`
-- `Title` (professional headline)
 - `Location`
 - `ContactEmail` and `Phone`
+
+`Profile` represents an individual portfolio and references a `Person`. It includes:
+
+- `Title` (professional headline for the portfolio)
 - `SelfDescription` for a short biography
 - Lists of employment records, education records, certifications and personal projects
 


### PR DESCRIPTION
## Summary
- add new `Person` entity so a user can have multiple portfolios
- update `Profile` to reference `Person`
- expose a `PortfolioApiClient` and Razor pages to list and view portfolios
- document the new model

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68811d0804b08326b2a79b9ece4b218c