### PR TITLE
Move AllProjects logic to repository

### DIFF
--- a/ProjectPortfolio/Model/Entity/Profile.cs
+++ b/ProjectPortfolio/Model/Entity/Profile.cs
@@ -12,27 +12,4 @@ public class Profile : AEntity
     public List<EducationRecord> EducationHistory { get; set; } = new();
     public List<Certification> Certifications { get; set; } = new();
     public List<Project> PersonalProjects { get; set; } = new();
-
-    public IEnumerable<Project> AllProjects
-    {
-        get
-        {
-            return PersonalProjects.Concat(GetProjectsFromEmployment(EmploymentHistory));
-        }
-    }
-
-    private static IEnumerable<Project> GetProjectsFromEmployment(IEnumerable<EmploymentRecord> records)
-    {
-        foreach (var record in records)
-        {
-            foreach (var project in record.Projects)
-                yield return project;
-
-            if (record.Clients != null)
-            {
-                foreach (var clientProject in GetProjectsFromEmployment(record.Clients))
-                    yield return clientProject;
-            }
-        }
-    }
 }

--- a/ProjectPortfolio/Model/Repositories/IProfileRepository.cs
+++ b/ProjectPortfolio/Model/Repositories/IProfileRepository.cs
@@ -1,0 +1,8 @@
+using Model.Entity;
+
+namespace Model.Repositories;
+
+public interface IProfileRepository : IRepository<Profile>
+{
+    Task<IEnumerable<Project>> GetAllProjectsAsync(int profileId);
+}

--- a/ProjectPortfolio/Model/Repositories/ProfileRepository.cs
+++ b/ProjectPortfolio/Model/Repositories/ProfileRepository.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore;
+using Model.Entity;
+
+namespace Model.Repositories;
+
+public class ProfileRepository : Repository<Profile>, IProfileRepository
+{
+    public ProfileRepository(PortfolioContext context) : base(context)
+    {
+    }
+
+    public async Task<IEnumerable<Project>> GetAllProjectsAsync(int profileId)
+    {
+        var profile = await _context.Profiles
+            .Include(p => p.PersonalProjects)
+            .Include(p => p.EmploymentHistory)
+                .ThenInclude(e => e.Projects)
+            .Include(p => p.EmploymentHistory)
+                .ThenInclude(e => e.Clients)
+                    .ThenInclude(c => c.Projects)
+            .FirstOrDefaultAsync(p => p.ID == profileId);
+
+        if (profile is null) return Enumerable.Empty<Project>();
+
+        return GetProjects(profile);
+    }
+
+    private static IEnumerable<Project> GetProjects(Profile profile)
+    {
+        return profile.PersonalProjects.Concat(GetProjectsFromEmployment(profile.EmploymentHistory));
+    }
+
+    private static IEnumerable<Project> GetProjectsFromEmployment(IEnumerable<EmploymentRecord> records)
+    {
+        foreach (var record in records)
+        {
+            foreach (var project in record.Projects)
+                yield return project;
+
+            if (record.Clients != null)
+            {
+                foreach (var clientProject in GetProjectsFromEmployment(record.Clients))
+                    yield return clientProject;
+            }
+        }
+    }
+}

--- a/ProjectPortfolio/Model/Repositories/Repository.cs
+++ b/ProjectPortfolio/Model/Repositories/Repository.cs
@@ -5,7 +5,7 @@ namespace Model.Repositories;
 
 public class Repository<T> : IRepository<T> where T : AEntity
 {
-    private readonly PortfolioContext _context;
+    protected readonly PortfolioContext _context;
     private readonly DbSet<T> _dbSet;
 
     public Repository(PortfolioContext context)

--- a/ProjectPortfolio/Model/Repositories/ServiceCollectionExtensions.cs
+++ b/ProjectPortfolio/Model/Repositories/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddRepositories(this IServiceCollection services)
     {
         services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
+        services.AddScoped<IProfileRepository, ProfileRepository>();
         return services;
     }
 }

--- a/ProjectPortfolio/WebAPI/Controllers/ProfilesController.cs
+++ b/ProjectPortfolio/WebAPI/Controllers/ProfilesController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc;
 using Model.Entity;
 using Model.Repositories;
 
@@ -5,7 +6,17 @@ namespace WebAPI.Controllers;
 
 public class ProfilesController : CrudController<Profile>
 {
-    public ProfilesController(IRepository<Profile> repository) : base(repository)
+    private readonly IProfileRepository _profiles;
+
+    public ProfilesController(IProfileRepository repository) : base(repository)
     {
+        _profiles = repository;
+    }
+
+    [HttpGet("{id}/projects")]
+    public async Task<ActionResult<IEnumerable<Project>>> GetAllProjects(int id)
+    {
+        var projects = await _profiles.GetAllProjectsAsync(id);
+        return Ok(projects);
     }
 }

--- a/ProjectPortfolio/WebAppRazor/Pages/Portfolio/Index.cshtml
+++ b/ProjectPortfolio/WebAppRazor/Pages/Portfolio/Index.cshtml
@@ -15,7 +15,7 @@ else
 
     <h2>Projects</h2>
     <ul>
-    @foreach (var proj in Model.Profile.AllProjects)
+    @foreach (var proj in Model.Projects)
     {
         <li>@proj.Title</li>
     }

--- a/ProjectPortfolio/WebAppRazor/Pages/Portfolio/Index.cshtml.cs
+++ b/ProjectPortfolio/WebAppRazor/Pages/Portfolio/Index.cshtml.cs
@@ -9,6 +9,7 @@ public class IndexModel : PageModel
     private readonly PortfolioApiClient _api;
 
     public Profile? Profile { get; set; }
+    public List<Project> Projects { get; set; } = new();
 
     public IndexModel(PortfolioApiClient api)
     {
@@ -18,5 +19,6 @@ public class IndexModel : PageModel
     public async Task OnGetAsync(int id)
     {
         Profile = await _api.GetProfileAsync(id);
+        Projects = await _api.GetProjectsForProfileAsync(id);
     }
 }

--- a/ProjectPortfolio/WebAppRazor/Services/PortfolioApiClient.cs
+++ b/ProjectPortfolio/WebAppRazor/Services/PortfolioApiClient.cs
@@ -22,4 +22,10 @@ public class PortfolioApiClient
     {
         return await _client.GetFromJsonAsync<Profile>($"profiles/{id}");
     }
+
+    public async Task<List<Project>> GetProjectsForProfileAsync(int id)
+    {
+        var result = await _client.GetFromJsonAsync<List<Project>>($"profiles/{id}/projects");
+        return result ?? new List<Project>();
+    }
 }


### PR DESCRIPTION
## Summary
- create `IProfileRepository` and `ProfileRepository`
- expose `GetAllProjectsAsync` via new endpoint in `ProfilesController`
- register the new repository in DI
- remove `AllProjects` property from `Profile` entity
- update Razor pages and API client to use new endpoint
- allow derived repositories to access `PortfolioContext`

## Testing
- `dotnet build ProjectPortfolio/ProjectPortfolio.sln`

------
https://chatgpt.com/codex/tasks/task_e_6881201a4af08326905c4c90abc856f2