### PR TITLE
Fix local debug base URLs

### DIFF
--- a/ProjectPortfolio/WebAppRazor/Program.cs
+++ b/ProjectPortfolio/WebAppRazor/Program.cs
@@ -2,9 +2,12 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 
+var apiBaseUrl = builder.Configuration.GetValue<string>("PortfolioApiBaseUrl");
+
 builder.Services.AddHttpClient<WebAppRazor.Services.PortfolioApiClient>(client =>
 {
-    client.BaseAddress = new Uri("http://webapi");
+    var baseAddress = string.IsNullOrEmpty(apiBaseUrl) ? "http://webapi" : apiBaseUrl;
+    client.BaseAddress = new Uri(baseAddress);
 });
 
 // Add services to the container.

--- a/ProjectPortfolio/WebAppRazor/appsettings.Development.json
+++ b/ProjectPortfolio/WebAppRazor/appsettings.Development.json
@@ -1,5 +1,6 @@
 {
   "DetailedErrors": true,
+  "PortfolioApiBaseUrl": "https://localhost:7130",
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/README.md
+++ b/README.md
@@ -31,3 +31,12 @@ dotnet ef migrations add InitialCreate --project ProjectPortfolio/Model --startu
 
 Migrations will be placed in the `Model` project and can be applied with
 `dotnet ef database update`.
+
+## Local debugging
+
+When running the solution from Visual Studio, start both the `WebAPI` and
+`WebAppRazor` projects using their HTTPS profiles. The API listens on
+`https://localhost:7130` while the web app runs on `https://localhost:7177`.
+`WebAppRazor` reads the API endpoint from the `PortfolioApiBaseUrl`
+configuration value, which is preconfigured in
+`WebAppRazor/appsettings.Development.json` for local debugging.


### PR DESCRIPTION
## Summary
- configure WebAppRazor to read `PortfolioApiBaseUrl` from config
- set default base URL in appsettings.Development.json
- document local debugging ports

## Testing
- `dotnet build ProjectPortfolio/ProjectPortfolio.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6881219a10388326a45ddc4055b22efc